### PR TITLE
feat: add option to download results

### DIFF
--- a/src/components/ValidationResults.jsx
+++ b/src/components/ValidationResults.jsx
@@ -51,13 +51,7 @@ const ValidationResults = ({
         <h2 id="validation-results-header" tabIndex="-1" ref={resultsHeaderRef}>
           Validation results
         </h2>
-        <a
-          className="usa-button"
-          href={downloadUrl}
-          download="cms-hpt-validator-results.csv"
-        >
-          Download results as spreadsheet
-        </a>
+
         <div id="validation-results-body">
           {loading && (
             <p className="font-sans-l loading-skeleton">
@@ -72,6 +66,13 @@ const ValidationResults = ({
           )}
           {!loading && filename && (
             <>
+              <a
+                className="usa-button"
+                href={downloadUrl}
+                download="cms-hpt-validator-results.csv"
+              >
+                Download results as spreadsheet
+              </a>
               <h3>File name</h3>
               <Alert
                 type={filenameValid ? `success` : `error`}

--- a/src/components/ValidationResults.jsx
+++ b/src/components/ValidationResults.jsx
@@ -2,6 +2,22 @@ import React, { useEffect, useRef } from "react"
 import PropTypes from "prop-types"
 import { Grid, Alert, Table } from "@trussworks/react-uswds"
 
+const createCsvString = (errors, warnings) =>
+  "location,message,type\n" +
+  errors
+    .map(
+      ({ path, message }) => `"${path}","${message.replace(/"/gi, "")}","error"`
+    )
+
+    .join("\n") +
+  "\n" +
+  warnings
+    .map(
+      ({ path, message }) =>
+        `"${path}","${message.replace(/"/gi, "")}","warning"`
+    )
+    .join("\n")
+
 const ValidationResults = ({
   filename,
   filenameValid,
@@ -13,6 +29,11 @@ const ValidationResults = ({
   didMount,
 }) => {
   const resultsHeaderRef = useRef(null)
+
+  const blob = new Blob([createCsvString(errors, warnings)], {
+    type: "text/csv;charset=utf-8",
+  })
+  const downloadUrl = window.URL.createObjectURL(blob)
 
   useEffect(() => {
     if (didMount && !loading && resultsHeaderRef.current) {
@@ -30,6 +51,13 @@ const ValidationResults = ({
         <h2 id="validation-results-header" tabIndex="-1" ref={resultsHeaderRef}>
           Validation results
         </h2>
+        <a
+          className="usa-button"
+          href={downloadUrl}
+          download="cms-hpt-validator-results.csv"
+        >
+          Download results as spreadsheet
+        </a>
         <div id="validation-results-body">
           {loading && (
             <p className="font-sans-l loading-skeleton">


### PR DESCRIPTION
Adds a CSV download option, I think the display could be updated a bit but this was a first pass that at least includes USWDS styles.

In order to handle CSV formatting without getting too in the weeds or adding another library I'm just removing all existing quotes in the error messages and quoting each cell. We can try downloading a few to see how it looks

<img width="1017" alt="Screen Shot 2023-07-21 at 2 39 50 PM" src="https://github.com/CMSgov/hpt-validator-tool/assets/129543325/92f77c63-eb1f-405c-a718-272285cb1d8e">
