### PR TITLE
feat: allow for toggling location NPI

### DIFF
--- a/src/pages/wizard.jsx
+++ b/src/pages/wizard.jsx
@@ -23,6 +23,7 @@ const Wizard = () => {
       name: "",
       ein: "",
       fileType: "",
+      showNpi: null,
       npi: "",
     }
   )
@@ -103,22 +104,47 @@ const Wizard = () => {
                   value={state.name}
                   onChange={(e) => setState({ ...state, name: e.target.value })}
                 ></TextInput>
-                <FormGroup>
-                  <Label htmlFor="hospital-npi">NPI (optional)</Label>
-                  <span className="usa-hint">
-                    Enter the NPI for each hospital location with distinct
-                    prices
-                  </span>
-                  <TextInput
-                    id="hospital-npi"
-                    name="hospital-npi"
-                    type="text"
-                    value={state.npi}
-                    onChange={(e) =>
-                      setState({ ...state, npi: e.target.value })
-                    }
+                <Fieldset
+                  legend="Does your hospital have more than one location with distinct negotiated rates?"
+                  className="usa-form-group"
+                  onChange={(e) => {
+                    setState({ ...state, showNpi: e.target.value === "yes" })
+                  }}
+                >
+                  <Radio
+                    id="npi-yes"
+                    name="show-npi"
+                    label="Yes"
+                    value="yes"
+                    defaultChecked={state.showNpi}
                   />
-                </FormGroup>
+                  <Radio
+                    id="npi-no"
+                    name="show-npi"
+                    label="No"
+                    value="no"
+                    defaultChecked={state.showNpi === false}
+                  />
+                </Fieldset>
+                <div role="region" aria-live="polite">
+                  {state.showNpi && (
+                    <FormGroup>
+                      <Label htmlFor="hospital-npi">NPI (optional)</Label>
+                      <span className="usa-hint">
+                        Enter the NPI for a hospital location
+                      </span>
+                      <TextInput
+                        id="hospital-npi"
+                        name="hospital-npi"
+                        type="text"
+                        value={state.npi}
+                        onChange={(e) =>
+                          setState({ ...state, npi: e.target.value })
+                        }
+                      />
+                    </FormGroup>
+                  )}
+                </div>
                 <Fieldset
                   legend="File type"
                   className="usa-form-group"
@@ -131,14 +157,14 @@ const Wizard = () => {
                     name="input-type"
                     label="CSV"
                     value="csv"
-                    checked={state.fileType === "csv"}
+                    defaultChecked={state.fileType === "csv"}
                   />
                   <Radio
                     id="input-json"
                     name="input-type"
                     label="JSON"
                     value="json"
-                    checked={state.fileType === "json"}
+                    defaultChecked={state.fileType === "json"}
                   />
                 </Fieldset>
               </Form>
@@ -151,7 +177,8 @@ const Wizard = () => {
               >
                 {state.ein || "<ein>"}_
                 {state.name.replace(/\s/g, "-") || "<hospitalname>"}
-                {state.npi ? `_${state.npi}` : ``}_standardcharges.
+                {state.showNpi && state.npi ? `_${state.npi}` : ``}
+                _standardcharges.
                 {state.fileType || "<format>"}
               </pre>
               <Alert


### PR DESCRIPTION
## One line description of your change (less than 72 characters)

Add option to toggle hospital location NPI question on file wizard

## Problem

It's potentially confusing to know whether the hospital NPI is needed for the file name even though we marked it as "(optional)" in the field label.

## Solution

Added a question before showing the location NPI field that conditionally shows it.

<img width="720" alt="Screen Shot 2023-07-21 at 3 13 38 PM" src="https://github.com/CMSgov/hpt-validator-tool/assets/129543325/325a7aa0-20d6-4c89-b064-e5b557612e8c">

<img width="665" alt="Screen Shot 2023-07-21 at 3 13 43 PM" src="https://github.com/CMSgov/hpt-validator-tool/assets/129543325/3836cce5-6f4c-40e5-a968-d7eec5a0688c">

## Result

This should reduce confusion but we can continue to evaluate