### PR TITLE
Improve error messages in filename wizard.

### DIFF
--- a/src/pages/wizard.jsx
+++ b/src/pages/wizard.jsx
@@ -17,6 +17,9 @@ import Layout from "../layouts"
 
 const STORAGE_PATH = "cms-hpt-file-name-wizard"
 
+const EIN_REGEX = /^\d{2}-?\d{7}$/
+const NPI_REGEX = /^\d{10}$/
+
 const Wizard = () => {
   const [state, setState] = useState(
     JSON.parse(window.sessionStorage.getItem(STORAGE_PATH)) || {
@@ -54,7 +57,21 @@ const Wizard = () => {
     if (isValid) {
       return { type: "success", message: "File name is valid" }
     } else {
-      return { type: "error", message: `File name is invalid` }
+      if (!state.ein.match(EIN_REGEX)) {
+        return {
+          type: "error",
+          message: `EIN must be 9 digits in the format XX-XXXXXXX or XXXXXXXXX`,
+        }
+      } else if (state.showNpi && state.npi && !state.npi.match(NPI_REGEX)) {
+        return {
+          type: "error",
+          message: `NPI must be 10 digits with no dashes`,
+        }
+      } else {
+        // Should never happen - given valid input, we should always produce
+        // a valid filename
+        return { type: "error", message: `File name is invalid` }
+      }
     }
   }
 


### PR DESCRIPTION
## Problem

If the user gives the filename wizard an EIN or NPI with the wrong format, the wizards tells them the filename it generated is invalid without explaining why.

## Solution

If the filename we generated is invalid, see if we can figure out why, and report a more specific error message. We keep the generic error message just in case, but as far as I can tell it's now unreachable.

## Result

Before:
<img width="480" alt="Screenshot of the filename wizard. User has entered an EIN with only 8 digits, and gets the error: File name is invalid" src="https://github.com/CMSgov/hpt-validator-tool/assets/4495750/aadfe433-7d0f-4658-9692-9fbe0ecfb3a0">

After:
<img width="477" alt="As above, but the error message reads: EIN must be 9 digits in the format XX-XXXXXXX or XXXXXXXXX" src="https://github.com/CMSgov/hpt-validator-tool/assets/4495750/e7e13a7a-372e-4bcf-85ca-71efbbd9f359">

## Test Plan

Manually tested with a few valid and invalid EINs and NPIs.