### PR TITLE
moving examples from the right side of the page to the left

### DIFF
--- a/src/pages/txt-generator.jsx
+++ b/src/pages/txt-generator.jsx
@@ -282,6 +282,100 @@ const TxtGenerator = () => {
               </Grid>
 
               <pre id="generator-output">{txtFileOutput(state.hospitals)}</pre>
+              <br />
+              <h3 className="margin-bottom-0">
+                <u>Example #1 TXT File</u>
+              </h3>
+              <p>
+                This TXT file example demonstrates a scenario in which a
+                hospital has two locations (“Example Hospital East” and “Example
+                Hospital West”), each with its own set of standard charges.
+                Under the regulation, the hospital must maintain a separate MRF
+                for each location. A single TXT file, hosted in the root folder
+                of the hospital’s website, would include information for both
+                locations and their corresponding MRFs as separate entries.
+              </p>
+              <p>
+                In this example, the hospital’s website hosts the directly
+                downloadable links to the MRFs on the same source page, so the
+                source page URL is the same for both entries. However, the MRF
+                URL for each of the entries is unique.{" "}
+              </p>
+              <p>
+                Finally, in this example, the POC for the first MRF is a person
+                (Jon Snow) that can be reached at jsnow@example.com.
+              </p>
+              <p id="generator-output">
+                location-name: Example Hospital East
+                <br />
+                source-page-url: https://example.com/price-transparency
+                <br />
+                mrf-url:
+                https://example.com/price-transparency/123456789_Example-Hospital-East_standardcharges.csv
+                <br />
+                contact-name: Jon Snow <br />
+                contact-email: jsnow@example.com <br />
+                <br />
+                location-name: Example Hospital West
+                <br />
+                source-page-url: https://example.com/price-transparency <br />
+                mrf-url:
+                https://example.com/price-transparency/987654321_Example-Hospital-West_standardcharges.json
+                <br />
+                contact-name: Jane Doe <br />
+                contact-email: jdoe@example2.com <br />
+              </p>
+              <h3 className="margin-bottom-0">
+                <u>Example #2 TXT File</u>
+              </h3>
+              <p>
+                This TXT file example demonstrates a scenario in which a
+                hospital has two locations (“Sample Hospital” and “Sample
+                Standalone Emergency Department”) that share the same set of
+                standard charges. Under the regulation, it is permissible for
+                the two locations to share a single MRF. A single TXT file would
+                include information for both locations as separate entries and
+                repeat the shared source page URL and MRF URL.
+              </p>
+              <p>
+                In this example, the hospital’s “vendor” hosts the single MRF
+                for the hospital on the vendor’s website. The TXT file should
+                indicate the vendor’s source page URL and the MRF URL
+                established by the vendor for the MRF.
+              </p>
+              <p>
+                Finally, in this example, the POC for the file is a team of
+                people (MRF Department) that share an email address
+                (MRFteam@sample.com).
+              </p>
+              <p id="generator-output">
+                location-name: Sample Hospital <br />
+                source-page-url:
+                https://vendor.com/hospital-price-transparency-files/links/samplehospital.aspx
+                <br />
+                mrf-url:
+                https://vendor.com/hospital-price-transparency-files/links
+                /101010101_Sample_standardcharges.csv
+                <br />
+                contact-name: MRF Department
+                <br />
+                contact-email: MRFteam@sample.com
+                <br />
+                <br />
+                location-name: Sample Standalone Emergency Department
+                <br />
+                source-page-url:
+                https://vendor.com/hospital-price-transparency-files/links/samplehospital.aspx
+                <br />
+                mrf-url:
+                https://vendor.com/hospital-price-transparency-files/links
+                /101010101_Sample_standardcharges.csv
+                <br />
+                contact-name: MRF Department
+                <br />
+                contact-email: MRFteam@sample.com
+                <br />
+              </p>
             </Grid>
             <Grid
               gap
@@ -443,99 +537,6 @@ const TxtGenerator = () => {
                   </td>
                 </tr>
               </table>
-              <h3 className="margin-bottom-0">
-                <u>Example #1 TXT File</u>
-              </h3>
-              <p>
-                This TXT file example demonstrates a scenario in which a
-                hospital has two locations (“Example Hospital East” and “Example
-                Hospital West”), each with its own set of standard charges.
-                Under the regulation, the hospital must maintain a separate MRF
-                for each location. A single TXT file, hosted in the root folder
-                of the hospital’s website, would include information for both
-                locations and their corresponding MRFs as separate entries.
-              </p>
-              <p>
-                In this example, the hospital’s website hosts the directly
-                downloadable links to the MRFs on the same source page, so the
-                source page URL is the same for both entries. However, the MRF
-                URL for each of the entries is unique.{" "}
-              </p>
-              <p>
-                Finally, in this example, the POC for the first MRF is a person
-                (Jon Snow) that can be reached at jsnow@example.com.
-              </p>
-              <p id="generator-output">
-                location-name: Example Hospital East
-                <br />
-                source-page-url: https://example.com/price-transparency
-                <br />
-                mrf-url:
-                https://example.com/price-transparency/123456789_Example-Hospital-East_standardcharges.csv
-                <br />
-                contact-name: Jon Snow <br />
-                contact-email: jsnow@example.com <br />
-                <br />
-                location-name: Example Hospital West
-                <br />
-                source-page-url: https://example.com/price-transparency <br />
-                mrf-url:
-                https://example.com/price-transparency/987654321_Example-Hospital-West_standardcharges.json
-                <br />
-                contact-name: Jane Doe <br />
-                contact-email: jdoe@example2.com <br />
-              </p>
-              <h3 className="margin-bottom-0">
-                <u>Example #2 TXT File</u>
-              </h3>
-              <p>
-                This TXT file example demonstrates a scenario in which a
-                hospital has two locations (“Sample Hospital” and “Sample
-                Standalone Emergency Department”) that share the same set of
-                standard charges. Under the regulation, it is permissible for
-                the two locations to share a single MRF. A single TXT file would
-                include information for both locations as separate entries and
-                repeat the shared source page URL and MRF URL.
-              </p>
-              <p>
-                In this example, the hospital’s “vendor” hosts the single MRF
-                for the hospital on the vendor’s website. The TXT file should
-                indicate the vendor’s source page URL and the MRF URL
-                established by the vendor for the MRF.
-              </p>
-              <p>
-                Finally, in this example, the POC for the file is a team of
-                people (MRF Department) that share an email address
-                (MRFteam@sample.com).
-              </p>
-              <p id="generator-output">
-                location-name: Sample Hospital <br />
-                source-page-url:
-                https://vendor.com/hospital-price-transparency-files/links/samplehospital.aspx
-                <br />
-                mrf-url:
-                https://vendor.com/hospital-price-transparency-files/links
-                /101010101_Sample_standardcharges.csv
-                <br />
-                contact-name: MRF Department
-                <br />
-                contact-email: MRFteam@sample.com
-                <br />
-                <br />
-                location-name: Sample Standalone Emergency Department
-                <br />
-                source-page-url:
-                https://vendor.com/hospital-price-transparency-files/links/samplehospital.aspx
-                <br />
-                mrf-url:
-                https://vendor.com/hospital-price-transparency-files/links
-                /101010101_Sample_standardcharges.csv
-                <br />
-                contact-name: MRF Department
-                <br />
-                contact-email: MRFteam@sample.com
-                <br />
-              </p>
             </Grid>
           </Grid>
         </section>


### PR DESCRIPTION
Reformatting txt-generator HTML layout.