### PR TITLE
Add support for HTML meta tag output

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -78,3 +78,7 @@ body,
   max-width: 100%;
   overflow-x: scroll;
 }
+
+.output-format-fieldset {
+  margin-top: 0;
+}


### PR DESCRIPTION
## One line description of your change (less than 72 characters)

Adds an option to output HTML meta tags instead of TXT on the generator

## Problem

There have been some issues with hospitals using more restrictive content management systems having difficulty placing a file at the root of their domain at /cms-hpt.txt. Offering an option to modify HTML meta tags with some of the output instead would provide another option to place the information in meta tags which would be more straightforward for hospitals with one or only a few locations. Modifying meta tags is much more commonly supported by even limited content management systems.

## Solution

Adds a radio button input that toggles whether the output should be .txt or .html and modifies the output and generated filename accordingly.

Important note that this does not modify any of the instructions since that would take more conversation, but is a simpler content update.

## Result

Including a screenshot below of the changed output

<img width="1080" alt="Screenshot 2024-03-18 at 5 45 21 PM" src="https://github.com/CMSgov/hpt-tool/assets/129543325/83d66fe4-e7ec-4187-9af6-88e440bc865c">

## Test Plan

The same tests for validating the TXT generator output should work here, with the addition of toggling the output format.
