### PR TITLE
Use validator 1.6.2 for next release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hpt-validator-tool",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hpt-validator-tool",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "CC0-1.0",
       "dependencies": {
         "@babel/preset-react": "^7.23.3",
@@ -15,7 +15,7 @@
         "buffer": "^6.0.3",
         "classnames": "^2.3.2",
         "clipboard": "^2.0.11",
-        "hpt-validator": "1.6.1",
+        "hpt-validator": "1.6.2",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -4444,10 +4444,9 @@
       }
     },
     "node_modules/hpt-validator": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/hpt-validator/-/hpt-validator-1.6.1.tgz",
-      "integrity": "sha512-d8CF3M7e7dsX42p296dV/Xy12PF4vGlp2DhmQiux3RXEsSHkIeqP/ce9gTvHb98GD2V9nkfjL/psVuroAVvT5w==",
-      "license": "CC0-1.0",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/hpt-validator/-/hpt-validator-1.6.2.tgz",
+      "integrity": "sha512-JIGcQW1xsnKJccwBM8v/zjWcnb8DTfcjntoVJBnmwaJMnLDBue0Jf7ayXaDlOVo2Wj4le4uLQVYUl6rsumeCIw==",
       "dependencies": {
         "@streamparser/json": "^0.0.17",
         "@types/node": "^20.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hpt-validator-tool",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "author": "CMS Open Source <opensource@cms.hhs.gov>",
   "license": "CC0-1.0",
   "description": "Validator tool for CMS Hospital Price Transparency machine-readable files",
@@ -40,7 +40,7 @@
     "buffer": "^6.0.3",
     "classnames": "^2.3.2",
     "clipboard": "^2.0.11",
-    "hpt-validator": "1.6.1",
+    "hpt-validator": "1.6.2",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
See https://github.com/CMSgov/hpt-validator/releases/tag/v1.6.2 for changes present in new version of `hpt-validator` package.