### PR TITLE
Update validator core to v1.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hpt-validator-tool",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hpt-validator-tool",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "license": "CC0-1.0",
       "dependencies": {
         "@babel/preset-react": "^7.23.3",
@@ -15,7 +15,7 @@
         "buffer": "^6.0.3",
         "classnames": "^2.3.2",
         "clipboard": "^2.0.11",
-        "hpt-validator": "1.7.0",
+        "hpt-validator": "1.7.1",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -4444,9 +4444,9 @@
       }
     },
     "node_modules/hpt-validator": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/hpt-validator/-/hpt-validator-1.7.0.tgz",
-      "integrity": "sha512-6sycU1PJuFdi6c3ILox6XOoG24kHCfzbMpKr/gUXPH/rZyPqQKLAwE8e5+0OOOa5fiKTjNlfeUnsHUg7lWbvtw==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/hpt-validator/-/hpt-validator-1.7.1.tgz",
+      "integrity": "sha512-bsIPMqZdCO4gAUJ81cNsw4krnMX0mTz22qujvtv86kHbNandWEYKnzAV7+D6C24igs9F+ULrB8W05m1aZ5ZYhg==",
       "dependencies": {
         "@streamparser/json": "^0.0.17",
         "@types/node": "^20.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hpt-validator-tool",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "author": "CMS Open Source <opensource@cms.hhs.gov>",
   "license": "CC0-1.0",
   "description": "Validator tool for CMS Hospital Price Transparency machine-readable files",
@@ -40,7 +40,7 @@
     "buffer": "^6.0.3",
     "classnames": "^2.3.2",
     "clipboard": "^2.0.11",
-    "hpt-validator": "1.7.0",
+    "hpt-validator": "1.7.1",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
For information about the changes this includes, see [release notes for hpt-validator v1.7.1](https://github.com/CMSgov/hpt-validator/releases/tag/v1.7.1).

Increase patch version to reflect new bugfixes.