### PR TITLE
Prevent invalid files in online validator file selection

### DIFF
--- a/src/components/FileInput.jsx
+++ b/src/components/FileInput.jsx
@@ -54,8 +54,8 @@ export const FileInput = ({
     if (accept) {
       const acceptedTypes = accept.split(",")
       let allFilesAllowed = true
-      for (let i = 0; i < e.dataTransfer.files.length; i += 1) {
-        const file = e.dataTransfer.files[parseInt(`${i}`)]
+      for (let i = 0; i < e.target.files.length; i += 1) {
+        const file = e.target.files[parseInt(`${i}`)]
         if (allFilesAllowed) {
           for (let j = 0; j < acceptedTypes.length; j += 1) {
             const fileType = acceptedTypes[parseInt(`${j}`)]
@@ -73,6 +73,7 @@ export const FileInput = ({
         e.preventDefault()
         e.stopPropagation()
       }
+      return allFilesAllowed
     }
   }
 
@@ -80,15 +81,16 @@ export const FileInput = ({
   const handleDragOver = () => setIsDragging(true)
   const handleDragLeave = () => setIsDragging(false)
   const handleDrop = (e) => {
-    preventInvalidFiles(e)
     setIsDragging(false)
     if (onDrop) onDrop(e)
   }
 
   const handleChange = (e) => {
-    setShowError(false)
-    setFile(e.target.files.length > 0 ? e.target.files[0] : null)
-    if (onChange) onChange(e)
+    const allFilesAllowed = preventInvalidFiles(e)
+    if (allFilesAllowed) {
+      setFile(e.target.files.length > 0 ? e.target.files[0] : null)
+      if (onChange) onChange(e)
+    }
   }
 
   return (


### PR DESCRIPTION
A file may be submitted to the online validator by drag-and-drop or by using a file selection window. In both cases, prevent the submission of files that are not one of the accepted types, and show an error when the file is not one of the accepted types.

## Problem

When a file that is not an allowed type is submitted to the online MRF validator using the file selection window, no error message appears. Instead, the "loading" message appears and remains on screen.

## Solution

Move the validation to the `onChange` event so that it occurs regardless of the user interaction mode.

## Test Plan

Submit an invalid file (such as .xlsx) to the online MRF validator using drag and drop and using the file selection window. In both cases, the same error message should be displayed indicating that this file is not one of the allowed types.
