### PR TITLE
Update hpt-validator package to 1.9.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hpt-validator-tool",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hpt-validator-tool",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "CC0-1.0",
       "dependencies": {
         "@babel/preset-react": "^7.25.7",
@@ -15,7 +15,7 @@
         "buffer": "^6.0.3",
         "classnames": "^2.5.1",
         "clipboard": "^2.0.11",
-        "hpt-validator": "^1.9.2",
+        "hpt-validator": "^1.9.3",
         "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -4703,9 +4703,9 @@
       }
     },
     "node_modules/hpt-validator": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/hpt-validator/-/hpt-validator-1.9.2.tgz",
-      "integrity": "sha512-IVCA22jnGOBp87y7mfrWLqqu2u85ahtNprED2mrBPN4KOES4nINGnaamQkikxEMOg7QOXvXbOQCqmMw/x8X1dw==",
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/hpt-validator/-/hpt-validator-1.9.3.tgz",
+      "integrity": "sha512-YUpHYkQeffeEukxbM+PwGCjeylG8gH1XtbJ3LOD5BUceEnUg20aOfM8RIjgJWdzvb+cAwJIncQZPx/VwV8RMNg==",
       "license": "CC0-1.0",
       "dependencies": {
         "@streamparser/json": "^0.0.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hpt-validator-tool",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "author": "CMS Open Source <opensource@cms.hhs.gov>",
   "license": "CC0-1.0",
   "description": "Validator tool for CMS Hospital Price Transparency machine-readable files",
@@ -41,7 +41,7 @@
     "buffer": "^6.0.3",
     "classnames": "^2.5.1",
     "clipboard": "^2.0.11",
-    "hpt-validator": "^1.9.2",
+    "hpt-validator": "^1.9.3",
     "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",


### PR DESCRIPTION
This patch update to the validator core means that this is also a patch update for the online validator. The information from the hpt-validator 1.9.3 patch release is:
> This is a patch release to fix a bug related to checks on modifiers in
CSV files. The requirements for modifiers will begin to be enforced January 1, 2025.