### PR TITLE
drag and drop onchange now triggers more than once with the same file name

### DIFF
--- a/src/components/FileInput.jsx
+++ b/src/components/FileInput.jsx
@@ -91,6 +91,8 @@ export const FileInput = ({
       setFile(e.target.files.length > 0 ? e.target.files[0] : null)
       if (onChange) onChange(e)
     }
+    // Clear out the value to allow for the same filename to trigger the onChange multiple times in a row.
+    e.target.value = null
   }
 
   return (


### PR DESCRIPTION
Clearing out the event target's value allows for the onChange event handler to be triggered multiple times when the file name is the same.