### PR TITLE
Remove warning text and output section

### DIFF
--- a/src/components/ValidationResults.jsx
+++ b/src/components/ValidationResults.jsx
@@ -157,59 +157,6 @@ const ValidationResults = ({
                   </Table>
                 </>
               )}
-              <h3>Warnings</h3>
-              <Alert type={warnings.length === 0 ? `success` : `warning`}>
-                {warnings.length === 0 ? (
-                  <>
-                    <span className="text-bold">No warnings found in file</span>
-                    : <span className="text-underline">{filename}</span>
-                  </>
-                ) : (
-                  <>
-                    <span className="text-bold">
-                      There
-                      {warnings.length === 1
-                        ? " is 1 warning"
-                        : ` are ${atMaxWarnings ? "at least " : ""}${
-                            warnings.length
-                          } warnings`}{" "}
-                      found in the file
-                    </span>
-                    : <span className="text-underline">{filename}</span>
-                    <br />
-                    {atMaxWarnings && (
-                      <span>
-                        The first {maxErrors} warnings are shown below.
-                      </span>
-                    )}
-                    <br />
-                    <span>
-                      These warnings represent requirements that are enforced
-                      beginning January 1, 2025.
-                    </span>
-                  </>
-                )}
-              </Alert>
-              {warnings.length > 0 && (
-                <Table className="width-full" bordered striped>
-                  <thead>
-                    <tr>
-                      <th scope="col">{locationHeader}</th>
-                      <th scope="col">Warning description</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {warnings
-                      .slice(0, maxErrors)
-                      .map(({ path, message }, index) => (
-                        <tr key={index}>
-                          <td>{path}</td>
-                          <td>{message}</td>
-                        </tr>
-                      ))}
-                  </tbody>
-                </Table>
-              )}
             </>
           )}
         </div>

--- a/src/pages/online-validator.jsx
+++ b/src/pages/online-validator.jsx
@@ -156,18 +156,15 @@ const OnlineValidator = () => {
                   required CMS template layout and data specifications. If your
                   MRF does not conform to the form and manner requirements, the
                   Online Validator will generate an output consisting of
-                  &apos;errors&apos; and &apos;warnings&apos;. Online Validator
-                  &apos;errors&apos; represent requirements that are enforced
-                  beginning July 1, 2024, whereas &apos;warnings&apos; represent
-                  requirements that are enforced beginning January 1, 2025. The
-                  Online Validator stops reviewing an MRF if there are more than
-                  250 errors. Additionally for CSV MRFs, the Online Validator
-                  stops reviewing if an error is found in row 1 through 3 (i.e.,
-                  errors in the general data element headers, general data
-                  element values, and standard charges, item/service, and coding
-                  headers). You should therefore address each error displayed
-                  and run your MRF through the Online Validator repeatedly until
-                  no more errors are generated.
+                  &apos;errors&apos;. The Online Validator stops reviewing an
+                  MRF if there are more than 250 errors. Additionally for CSV
+                  MRFs, the Online Validator stops reviewing if an error is
+                  found in row 1 through 3 (i.e., errors in the general data
+                  element headers, general data element values, and standard
+                  charges, item/service, and coding headers). You should
+                  therefore address each error displayed and run your MRF
+                  through the Online Validator repeatedly until no more errors
+                  are generated.
                 </p>
                 <p>
                   <strong>


### PR DESCRIPTION
The validator no longer produces warnings, as there are no future requirements implemented in the validator. Remove the text that explains warnings to avoid confusion. Remove the warning output section, since it will always report 0 warnings.
