### PR TITLE
update deployment workflow to use newer upload-pages-artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/configure-pages@v3
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist
 


### PR DESCRIPTION
Versions of `deploy-pages` prior to v4 are deprecated and no longer work. The v3 version of `upload-pages-artifact` uses the v4 version of `deploy-pages`. Additional information: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/