### PR TITLE
update version of deploy-pages action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,4 +81,4 @@ jobs:
           path: ./dist
 
       - name: Deploy to GitHub pages
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Errors occurred with v2 of `deploy-pages`. Code samples suggest that v4 may work correctly.