### PR TITLE
Update to use namespaced package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,12 @@
       "license": "CC0-1.0",
       "dependencies": {
         "@babel/preset-react": "^7.25.7",
+        "@cmsgov/hpt-validator": "^1.11.1",
         "@trussworks/react-uswds": "^9.1.0",
         "@uswds/uswds": "3.9.0",
         "buffer": "^6.0.3",
         "classnames": "^2.5.1",
         "clipboard": "^2.0.11",
-        "hpt-validator": "^1.11.1",
         "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -1625,6 +1625,52 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@cmsgov/hpt-validator": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@cmsgov/hpt-validator/-/hpt-validator-1.11.1.tgz",
+      "integrity": "sha512-Vtznhty5KSzUsuGu1o7DXwrKoc39ekxf4XeBiALQoZxTXG1QVZ+E022VWAdeH/zRM675cr6wgKoRqfe3I1yDzA==",
+      "dependencies": {
+        "@streamparser/json": "^0.0.21",
+        "@types/node": "^20.16.5",
+        "@types/papaparse": "^5.3.14",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "papaparse": "^5.4.1"
+      }
+    },
+    "node_modules/@cmsgov/hpt-validator/node_modules/@types/node": {
+      "version": "20.19.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.8.tgz",
+      "integrity": "sha512-HzbgCY53T6bfu4tT7Aq3TvViJyHjLjPNaAS3HOuMc9pw97KHsUtXNX4L+wu59g1WnjsZSko35MbEqnO58rihhw==",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@cmsgov/hpt-validator/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@cmsgov/hpt-validator/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/@cmsgov/hpt-validator/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.2",
@@ -5108,51 +5154,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/hpt-validator": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/hpt-validator/-/hpt-validator-1.11.1.tgz",
-      "integrity": "sha512-fVluFcruAs+OC0ZkXTxez2b8xnwU0kIAQbkOBsazbaawqgV//xm8/MxjuSSLZtvxOUnWPEM9RplcqJRQZ5gKtw==",
-      "license": "CC0-1.0",
-      "dependencies": {
-        "@streamparser/json": "^0.0.21",
-        "@types/node": "^20.16.5",
-        "@types/papaparse": "^5.3.14",
-        "ajv": "^8.17.1",
-        "ajv-formats": "^3.0.1",
-        "papaparse": "^5.4.1"
-      }
-    },
-    "node_modules/hpt-validator/node_modules/@types/node": {
-      "version": "20.17.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.1.tgz",
-      "integrity": "sha512-j2VlPv1NnwPJbaCNv69FO/1z4lId0QmGvpT41YxitRtWlg96g/j8qcv2RKsLKe2F6OJgyXhupN1Xo17b2m139Q==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.19.2"
-      }
-    },
-    "node_modules/hpt-validator/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/hpt-validator/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "buffer": "^6.0.3",
     "classnames": "^2.5.1",
     "clipboard": "^2.0.11",
-    "hpt-validator": "^1.11.1",
+    "@cmsgov/hpt-validator": "^1.11.1",
     "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/pages/online-validator.jsx
+++ b/src/pages/online-validator.jsx
@@ -9,7 +9,7 @@ import {
 } from "@trussworks/react-uswds"
 import { FileInput } from "../components/FileInput"
 import ValidationResults from "../components/ValidationResults"
-import { validateCsv, validateJson } from "hpt-validator"
+import { validateCsv, validateJson } from "@cmsgov/hpt-validator"
 import Layout from "../layouts"
 
 const MAX_ERRORS = 250

--- a/src/pages/wizard.jsx
+++ b/src/pages/wizard.jsx
@@ -12,7 +12,7 @@ import {
   TextInput,
   FormGroup,
 } from "@trussworks/react-uswds"
-import { validateFilename } from "hpt-validator"
+import { validateFilename } from "@cmsgov/hpt-validator"
 import Layout from "../layouts"
 
 const STORAGE_PATH = "cms-hpt-file-name-wizard"


### PR DESCRIPTION
## One line description of your change (less than 72 characters)

Updates to use the new namespaced `@cmsgov/hpt-validator` package

## Problem

The previous package name has been deprecated so we need to update it here
